### PR TITLE
Let systemd handle restarting crashed kodi

### DIFF
--- a/files/kodi.service
+++ b/files/kodi.service
@@ -8,6 +8,7 @@ User = kodi
 Group = kodi
 Type = simple
 ExecStart = /usr/bin/kodi
+Restart=on-failure
 
 [Install]
 WantedBy = multi-user.target


### PR DESCRIPTION
Kodi is quite stable , but using memory hogging experimental plugins like netflix
can sometimes crash it. So let systemd automatically restart it