### PR TITLE
Allow kodi to play rar:ed media content.

### DIFF
--- a/setup.yml
+++ b/setup.yml
@@ -18,6 +18,8 @@
       - ntp
       - avahi-utils
       - ca-certificates
+      - kodi-vfs-libarchive
+      - kodi-vfs-rar
 
     wifi_ssid:
     wifi_password:


### PR DESCRIPTION
Needs to be enabled in Kodi under  addons - virtual filesystems - archive support